### PR TITLE
Fix Applied

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -3,9 +3,21 @@ package clipboard
 
 import (
 	"fmt"
+	"sync"
+	"time"
 
 	"golang.design/x/clipboard"
 )
+
+var initOnce sync.Once
+var initErr error
+
+func initClipboard() error {
+	initOnce.Do(func() {
+		initErr = clipboard.Init()
+	})
+	return initErr
+}
 
 // Copy copies text to the clipboard
 func Copy(text string) error {
@@ -13,11 +25,19 @@ func Copy(text string) error {
 		return fmt.Errorf("nothing to copy")
 	}
 
-	// Initialize clipboard support once
-	clipboard.Init()
+	if err := initClipboard(); err != nil {
+		return fmt.Errorf("clipboard initialization failed: %w", err)
+	}
 
-	// Write returns a done channel, not an error — discard it
-	<-clipboard.Write(clipboard.FmtText, []byte(text))
+	done := clipboard.Write(clipboard.FmtText, []byte(text))
+	select {
+	case ok := <-done:
+		if !ok {
+			return fmt.Errorf("failed to copy to clipboard")
+		}
+	case <-time.After(200 * time.Millisecond):
+		go func() { <-done }()
+	}
 
 	return nil
 }


### PR DESCRIPTION
Updated clipboard.go to make clipboard copy return faster.

What changed
clipboard.Init() is now run once using sync.Once
clipboard writes are no longer forced to wait indefinitely if the write is slow, the command returns after 200ms while a goroutine finishes the write Result
kvstok copy ... or kvstok get --copy ... should feel responsive again copy still works, but the CLI no longer freezes waiting on the clipboard backend
	modified:   internal/clipboard/clipboard.go

Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.17
- [ ] 1.18
- [ ] 1.19

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
