### PR TITLE
Fix Applied

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -31,10 +31,8 @@ func Copy(text string) error {
 
 	done := clipboard.Write(clipboard.FmtText, []byte(text))
 	select {
-	case ok := <-done:
-		if !ok {
-			return fmt.Errorf("failed to copy to clipboard")
-		}
+	case <-done:
+		// successfully copied to clipboard
 	case <-time.After(200 * time.Millisecond):
 		go func() { <-done }()
 	}


### PR DESCRIPTION
Updated clipboard.go
Replaced the invalid boolean check on ok with a proper <-done receive from the chan struct{} returned by clipboard.Write Result
The compile error at internal/clipboard/clipboard.go:35:7 is fixed get_errors reports no issues in the edited file

Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.17
- [ ] 1.18
- [ ] 1.19

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
